### PR TITLE
change question to remove assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Keep in mind, we have intentionally omitted the answers to these questions.
 * Why is it more valuable to talk about today's upcoming work than yesterday's accomplishments?
 
 ### Agile
-* Why should we not push code when the build is red?
+* Should we not push code when the build is red?
 * What is continuous integration, and why do we do it?
 * What is the value of retro? Why is it weekly?
 * How do tests improve our confidence in our code's correctness?


### PR DESCRIPTION
"Why should we not push code when the build is red?" assumes the question "should we not push code when the build is red?" already has an answer of "no", and now just asking why.  But that question itself is valid, and there even are times when we push on red (e.g. the push will fix the redness, some critical situations, etc.)
